### PR TITLE
Include gettext in dependencies for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ubuntu:
 
 ```sh
 sudo apt install cmake extra-cmake-modules git libkf5package-dev libkf5plasma-dev \
-    libkf5i18n-dev qtbase5-dev qtdeclarative5-dev qtpositioning5-dev
+    libkf5i18n-dev qtbase5-dev qtdeclarative5-dev qtpositioning5-dev gettext
 ```
 
 Once all prerequisites are installed, you need to grab the source code


### PR DESCRIPTION
CMake fails without it
```
CMake Error at /usr/share/cmake-3.13/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find Gettext (missing: GETTEXT_MSGMERGE_EXECUTABLE
  GETTEXT_MSGFMT_EXECUTABLE)
```